### PR TITLE
A fix to the fix-path.config file

### DIFF
--- a/.ebextensions/fix-path.config
+++ b/.ebextensions/fix-path.config
@@ -1,3 +1,3 @@
 container_commands:
   fix_path:
-    command: "unzip continuous-delivery-back-demo-0.0.1-SNAPSHOT.war 2>&1 > /var/log/my_last_deploy.log"
+    command: "unzip revLocate-backend-0.0.1-SNAPSHOT.war 2>&1 > /var/log/my_last_deploy.log"


### PR DESCRIPTION
In the .ebextensions folder in the project, the artifact version is
incorrect. This was a fix to that. Elastic Beanstalk should work as of
this push.